### PR TITLE
Replace inline QML with proper Qt resource system

### DIFF
--- a/qt-app/CMakeLists.txt
+++ b/qt-app/CMakeLists.txt
@@ -8,9 +8,10 @@ set(CMAKE_AUTOMOC ON)
 # Find Qt6 - Core, Gui, and QML components
 find_package(Qt6 REQUIRED COMPONENTS Core Gui Qml Quick)
 
-# Create executable
+# Create executable with QML resources
 qt_add_executable(HelloWorldQt6
     main.cpp
+    qml.qrc
 )
 
 # Link Qt libraries

--- a/qt-app/main.cpp
+++ b/qt-app/main.cpp
@@ -16,49 +16,14 @@ int main(int argc, char *argv[])
 
     QQmlApplicationEngine engine;
 
-    // Load inline QML
-    engine.loadData(R"QML(
-import QtQuick 2.15
-import QtQuick.Window 2.15
+    // Load QML from Qt resource system
+    const QUrl url(QStringLiteral("qrc:/main.qml"));
+    qDebug() << "Loading QML from:" << url;
 
-Window {
-    visible: true
-    width: 390
-    height: 844
-    color: "#4CAF50"
-
-    Rectangle {
-        anchors.centerIn: parent
-        width: 300
-        height: 200
-        color: "white"
-        radius: 20
-
-        Column {
-            anchors.centerIn: parent
-            spacing: 20
-
-            Text {
-                text: "✅ Qt6 Works!"
-                font.pixelSize: 36
-                font.bold: true
-                color: "#4CAF50"
-                anchors.horizontalCenter: parent.horizontalCenter
-            }
-
-            Text {
-                text: "Hello from iOS"
-                font.pixelSize: 24
-                color: "#666"
-                anchors.horizontalCenter: parent.horizontalCenter
-            }
-        }
-    }
-}
-)QML");
+    engine.load(url);
 
     if (engine.rootObjects().isEmpty()) {
-        qDebug() << "ERROR: Failed to load QML";
+        qDebug() << "ERROR: Failed to load QML from" << url;
         return -1;
     }
 

--- a/qt-app/main.qml
+++ b/qt-app/main.qml
@@ -5,28 +5,32 @@ Window {
     visible: true
     width: 390
     height: 844
-    title: "Hello World"
+    title: "Qt6 iOS App"
+    color: "#4CAF50"
 
     Rectangle {
-        anchors.fill: parent
-        color: "#f5f5f5"
+        anchors.centerIn: parent
+        width: 300
+        height: 200
+        color: "white"
+        radius: 20
 
         Column {
             anchors.centerIn: parent
             spacing: 20
 
             Text {
-                text: "Hello World from Qt6!"
-                font.pixelSize: 32
+                text: "✅ Qt6 Works!"
+                font.pixelSize: 36
                 font.bold: true
-                color: "#007AFF"
+                color: "#4CAF50"
                 anchors.horizontalCenter: parent.horizontalCenter
             }
 
             Text {
-                text: "Built with GitHub Actions + CMake"
-                font.pixelSize: 16
-                color: "#666666"
+                text: "Hello from iOS"
+                font.pixelSize: 24
+                color: "#666"
                 anchors.horizontalCenter: parent.horizontalCenter
             }
         }


### PR DESCRIPTION
Fixes #2

## Summary
Replaced inline QML string literal with proper Qt resource system for better maintainability and tooling support.

## Changes
- ✅ Extracted QML code to separate `main.qml` file  
- ✅ Updated `main.cpp` to load QML via `qrc:/main.qml` URL
- ✅ Added `qml.qrc` to `qt_add_executable` in CMakeLists.txt
- ✅ Maintained same UI appearance (green background with "Qt6 Works!" text)

## Benefits
- **Standard Qt approach**: Uses Qt's recommended resource system
- **Better developer experience**: QML can be edited without C++ recompilation
- **IDE support**: Proper syntax highlighting and QML debugging
- **Modularity**: Foundation for splitting into reusable QML components
- **Cleaner code**: No 40-line raw string literals in C++

## Technical Details
```cpp
// Before: Inline QML
engine.loadData(R"QML(
import QtQuick 2.15
// ... 40 lines of QML ...
)QML");

// After: Resource system
const QUrl url(QStringLiteral("qrc:/main.qml"));
engine.load(url);
```

## Testing
- [ ] Build succeeds in GitHub Actions
- [ ] App deploys to iOS device  
- [ ] UI renders correctly with green background and text
- [ ] App doesn't crash on launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)